### PR TITLE
Updated to remove depreciation warning for comfy.samplers.calc_cond_uncond_batch

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -13,7 +13,7 @@ def sampling_function_patched(model, x, timestep, uncond, cond, cond_scale, mode
         else:
             uncond_ = uncond
 
-        cond_pred, uncond_pred = comfy.samplers.calc_cond_uncond_batch(model, cond, uncond_, x, timestep, model_options)
+        cond_pred, uncond_pred = comfy.samplers.calc_cond_batch(model, [cond, uncond_], x, timestep, model_options)
         if "sampler_cfg_function" in model_options:
             args = {"cond": x - cond_pred, "uncond": x - uncond_pred, "cond_scale": cond_scale, "timestep": timestep, "input": x, "sigma": timestep,
                     "cond_denoised": cond_pred, "uncond_denoised": uncond_pred, "model": model, "model_options": model_options}


### PR DESCRIPTION
Removes "WARNING: The comfy.samplers.calc_cond_uncond_batch function is deprecated please use the calc_cond_batch one instead."